### PR TITLE
Trailing Charecters in function Preview() (and doesn't work with spaces in filename)

### DIFF
--- a/plugin/main.vim
+++ b/plugin/main.vim
@@ -1,20 +1,26 @@
 let mapleader="\\"
 
-" TODO: If zathura open, refresh
 function! Preview()
-		call Compile()<CR><CR>
-		execute "! zathura /tmp/op.pdf &"
+	let extension = expand('%:e')
+	if extension == "ms"
+		execute "! groff -ms % -T pdf > /tmp/op.pdf"
+	elseif extension == "tex"
+		execute "! pandoc -f latex -t latex % -o /tmp/op.pdf"
+	elseif extension == "md"
+		execute "! pandoc % -s -o /tmp/op.pdf"
+	endif
+	execute "! zathura /tmp/op.pdf &"
 endfunction
 
 function! Compile()
-		let extension = expand('%:e')
-		if extension == "ms"
-				execute "! groff -ms % -T pdf > /tmp/op.pdf"
-		elseif extension == "tex"
-				execute "! pandoc -f latex -t latex % -o /tmp/op.pdf"
-		elseif extension == "md"
-				execute "! pandoc % -s -o /tmp/op.pdf"
-		endif
+	let extension = expand('%:e')
+	if extension == "ms"
+		execute "! groff -ms % -T pdf > /tmp/op.pdf"
+	elseif extension == "tex"
+		execute "! pandoc -f latex -t latex % -o /tmp/op.pdf"
+	elseif extension == "md"
+		execute "! pandoc % -s -o /tmp/op.pdf"
+	endif
 endfunction
 
 

--- a/plugin/main.vim
+++ b/plugin/main.vim
@@ -3,11 +3,11 @@ let mapleader="\\"
 function! Preview()
 	let extension = expand('%:e')
 	if extension == "ms"
-		execute "! groff -ms % -T pdf > /tmp/op.pdf"
+		execute "! groff -ms \"%\" -T pdf > /tmp/op.pdf"
 	elseif extension == "tex"
-		execute "! pandoc -f latex -t latex % -o /tmp/op.pdf"
+		execute "! pandoc -f latex -t latex \"%\" -o /tmp/op.pdf"
 	elseif extension == "md"
-		execute "! pandoc % -s -o /tmp/op.pdf"
+		execute "! pandoc \"%\" -s -o /tmp/op.pdf"
 	endif
 	execute "! zathura /tmp/op.pdf &"
 endfunction
@@ -15,11 +15,11 @@ endfunction
 function! Compile()
 	let extension = expand('%:e')
 	if extension == "ms"
-		execute "! groff -ms % -T pdf > /tmp/op.pdf"
+		execute "! groff -ms \"%\" -T pdf > /tmp/op.pdf"
 	elseif extension == "tex"
-		execute "! pandoc -f latex -t latex % -o /tmp/op.pdf"
+		execute "! pandoc -f latex -t latex \"%\" -o /tmp/op.pdf"
 	elseif extension == "md"
-		execute "! pandoc % -s -o /tmp/op.pdf"
+		execute "! pandoc \"%\" -s -o /tmp/op.pdf"
 	endif
 endfunction
 

--- a/plugin/main.vim
+++ b/plugin/main.vim
@@ -2,7 +2,7 @@ let mapleader="\\"
 
 " TODO: If zathura open, refresh
 function! Preview()
-		:call Compile()<CR><CR>
+		call Compile()<CR><CR>
 		execute "! zathura /tmp/op.pdf &"
 endfunction
 


### PR DESCRIPTION
Copying and pasting the compile function into the preview function fixed a problem for me in Neovim where it was telling me that there were "Trailing Charecters in the function Preview()"